### PR TITLE
Add support for Jekyll 4.0

### DIFF
--- a/jekyll_diff.sh
+++ b/jekyll_diff.sh
@@ -26,9 +26,11 @@ fi
 ####################################################
 
 cd /github/workspace
-jekyll build --destination /tmp/new/
+mkdir -p .jekyll-cache # workaround for https://github.com/jekyll/jekyll/issues/7591
+
+jekyll build --trace --destination /tmp/new/
 git checkout $common_ancestor_sha
-jekyll build --destination /tmp/old
+jekyll build --trace --destination /tmp/old
 diff="$(diff --recursive --new-file --unified=0 /tmp/old /tmp/new || true)" # 'or true' because a non-identical diff outputs 1 as the exit status
 
 


### PR DESCRIPTION
https://github.com/jekyll/jekyll/issues/7591 was failing builds that use Jekyll 4.0, as Github Actions use a lot of the same infrastructure as Azure Pipelines (so much so that they even share bugs!)